### PR TITLE
Replace WindowsAPICodePack dialog with OpenFolderDialog

### DIFF
--- a/OnlyR/OnlyR.csproj
+++ b/OnlyR/OnlyR.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Serilog.Sinks.File" />
-    <PackageReference Include="WinCopies.WindowsAPICodePack.Shell" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OnlyR.Core\OnlyR.Core.csproj" />

--- a/OnlyR/ViewModel/SettingsPageViewModel.cs
+++ b/OnlyR/ViewModel/SettingsPageViewModel.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using OnlyR.ViewModel.Messages;
-using Microsoft.WindowsAPICodePack.Dialogs;
+using Microsoft.Win32;
 using OnlyR.Model;
 using OnlyR.Services.Audio;
 using OnlyR.Services.Options;
@@ -436,14 +436,16 @@ public class SettingsPageViewModel : ObservableObject, IPage
 
     private void SelectDestinationFolder()
     {
-#pragma warning disable CA1416 // Validate platform compatibility
-        using var d = new CommonOpenFileDialog(Properties.Resources.SELECT_DEST_FOLDER) { IsFolderPicker = true };
-        var result = d.ShowDialog();
-        if (result == CommonFileDialogResult.Ok)
+        var dialog = new OpenFolderDialog
         {
-            DestinationFolder = d.FileName;
+            Title = Properties.Resources.SELECT_DEST_FOLDER,
+            InitialDirectory = DestinationFolder
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            DestinationFolder = dialog.FolderName;
         }
-#pragma warning restore CA1416 // Validate platform compatibility
     }
 
     private void ShowRecordings()


### PR DESCRIPTION
Removed dependency on WinCopies.WindowsAPICodePack.Shell and replaced CommonOpenFileDialog usage in SettingsPageViewModel with a new OpenFolderDialog. Updated using directives and refactored SelectDestinationFolder to improve platform compatibility and remove reliance on Windows API Code Pack.

