### PR TITLE
Remove WindowsAPICodePack dependency, refactor folder dialog

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="WinCopies.WindowsAPICodePack.Shell" Version="2.12.0.2" />
 
     <!-- OnlyR.Tests -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />

--- a/OnlyR/OnlyR.csproj
+++ b/OnlyR/OnlyR.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Serilog.Sinks.File" />
-    <PackageReference Include="WinCopies.WindowsAPICodePack.Shell" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OnlyR.Core\OnlyR.Core.csproj" />

--- a/OnlyR/ViewModel/SettingsPageViewModel.cs
+++ b/OnlyR/ViewModel/SettingsPageViewModel.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using OnlyR.ViewModel.Messages;
-using Microsoft.WindowsAPICodePack.Dialogs;
+using Microsoft.Win32;
 using OnlyR.Model;
 using OnlyR.Services.Audio;
 using OnlyR.Services.Options;
@@ -436,14 +436,16 @@ public class SettingsPageViewModel : ObservableObject, IPage
 
     private void SelectDestinationFolder()
     {
-#pragma warning disable CA1416 // Validate platform compatibility
-        using var d = new CommonOpenFileDialog(Properties.Resources.SELECT_DEST_FOLDER) { IsFolderPicker = true };
-        var result = d.ShowDialog();
-        if (result == CommonFileDialogResult.Ok)
+        var dialog = new OpenFolderDialog
         {
-            DestinationFolder = d.FileName;
+            Title = Properties.Resources.SELECT_DEST_FOLDER,
+            InitialDirectory = DestinationFolder
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            DestinationFolder = dialog.FolderName;
         }
-#pragma warning restore CA1416 // Validate platform compatibility
     }
 
     private void ShowRecordings()


### PR DESCRIPTION
Replaced CommonOpenFileDialog with OpenFolderDialog from Microsoft.Win32 in SettingsPageViewModel. Removed all references to WinCopies.WindowsAPICodePack.Shell from project files, simplifying dependencies and improving cross-platform compatibility.