### PR TITLE
Prevent overwriting of existing desktop shortcut

### DIFF
--- a/Installer/OnlyRSetup.iss
+++ b/Installer/OnlyRSetup.iss
@@ -43,7 +43,13 @@ Source: "..\OnlyR\bin\Release\net10.0-windows\publish\win-x86\*"; DestDir: "{app
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; Check: not DesktopShortcutExists
+
+[Code]
+function DesktopShortcutExists: Boolean;
+begin
+  Result := FileExists(ExpandConstant('{commondesktop}\{#MyAppName}.lnk'));
+end;
 
 [ThirdParty]
 UseRelativePaths=True


### PR DESCRIPTION
The target system may already have a shortcut from a previous installation, and the user may have specified some command-line arguments in the shortcut. This InnoSetup modification prevents us from overwriting a pre-existing shortcut and effectively removing the command-line arguments.