### PR TITLE
Improve settings page accessibility

### DIFF
--- a/OnlyR/Model/BitRateItem.cs
+++ b/OnlyR/Model/BitRateItem.cs
@@ -14,5 +14,7 @@
         public string Name { get; }
 
         public int ActualBitRate { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Model/ChannelItem.cs
+++ b/OnlyR/Model/ChannelItem.cs
@@ -14,5 +14,7 @@
         public string Name { get; }
 
         public int ChannelCount { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Model/CodecItem.cs
+++ b/OnlyR/Model/CodecItem.cs
@@ -16,5 +16,7 @@ namespace OnlyR.Model
         public string Name { get; }
 
         public AudioCodec Codec { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Model/LanguageItem.cs
+++ b/OnlyR/Model/LanguageItem.cs
@@ -11,5 +11,7 @@
         public string LanguageId { get; }
 
         public string LanguageName { get; }
+
+        public override string ToString() => LanguageName;
     }
 }

--- a/OnlyR/Model/MaxRecordingTimeItem.cs
+++ b/OnlyR/Model/MaxRecordingTimeItem.cs
@@ -14,5 +14,7 @@
         public string Name { get; }
 
         public int ActualSeconds { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Model/MaxSilenceTimeItem.cs
+++ b/OnlyR/Model/MaxSilenceTimeItem.cs
@@ -12,5 +12,7 @@
         public string Name { get; }
 
         public int Seconds { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Model/RecordingDeviceItem.cs
+++ b/OnlyR/Model/RecordingDeviceItem.cs
@@ -14,5 +14,7 @@
         public int DeviceId { get; }
 
         public string DeviceName { get; }
+
+        public override string ToString() => DeviceName;
     }
 }

--- a/OnlyR/Model/RecordingLifeTimeItem.cs
+++ b/OnlyR/Model/RecordingLifeTimeItem.cs
@@ -11,5 +11,7 @@
         public string Description { get; }
 
         public int Days { get; }
+
+        public override string ToString() => Description;
     }
 }

--- a/OnlyR/Model/SampleRateItem.cs
+++ b/OnlyR/Model/SampleRateItem.cs
@@ -14,5 +14,7 @@
         public string Name { get; }
 
         public int ActualSampleRate { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Model/ThemeModeItem.cs
+++ b/OnlyR/Model/ThemeModeItem.cs
@@ -14,5 +14,7 @@ namespace OnlyR.Model
         public string Name { get; }
 
         public AppTheme Theme { get; }
+
+        public override string ToString() => Name;
     }
 }

--- a/OnlyR/Pages/SettingsPage.xaml
+++ b/OnlyR/Pages/SettingsPage.xaml
@@ -175,12 +175,21 @@
                     SelectedValuePath="Seconds"
                     Style="{StaticResource SettingsComboStyle}" />
 
-                <Label Content="{x:Static resx:Resources.SETTINGS_SILENCE_AS_PERCENTAGE_VOLUME}" />
+                <Label
+                    x:Name="SilenceDetectionVolumeLabel"
+                    Content="{x:Static resx:Resources.SETTINGS_SILENCE_AS_PERCENTAGE_VOLUME}" />
                 <Slider
                     AutomationProperties.AutomationId="SilenceDetectionVolume"
+                    AutomationProperties.LabeledBy="{Binding ElementName=SilenceDetectionVolumeLabel}"
                     AutomationProperties.Name="{x:Static resx:Resources.SETTINGS_SILENCE_AS_PERCENTAGE_VOLUME}"
+                    Focusable="True"
+                    IsSnapToTickEnabled="True"
+                    IsTabStop="True"
+                    LargeChange="10"
+                    SmallChange="1"
                     Style="{StaticResource SliderStyle}"
-                    Value="{Binding SilenceAsVolumePercentage}" />
+                    TickFrequency="1"
+                    Value="{Binding SilenceAsVolumePercentage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                 <CheckBox
                     AutomationProperties.AutomationId="FadeOut"
@@ -248,7 +257,7 @@
                         Margin="10,0,5,10"
                         VerticalAlignment="Bottom"
                         AutomationProperties.AutomationId="SelectDestinationFolder"
-                        AutomationProperties.Name="{Binding SelectDestinationFolderCommand}"
+                        AutomationProperties.Name="{x:Static resx:Resources.SELECT_DEST_FOLDER}"
                         Command="{Binding SelectDestinationFolderCommand}"
                         DockPanel.Dock="Right">
                         ...
@@ -257,7 +266,7 @@
                         Margin="0,10,0,10"
                         materialDesign:HintAssist.Hint="{x:Static resx:Resources.SETTINGS_RECORDINGS_FOLDER}"
                         AutomationProperties.AutomationId="EditDestinationFolder"
-                        AutomationProperties.Name="SETTINGS_RECORDINGS_FOLDER"
+                        AutomationProperties.Name="{x:Static resx:Resources.SETTINGS_RECORDINGS_FOLDER}"
                         DockPanel.Dock="Left"
                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                         Text="{Binding DestinationFolder, Mode=TwoWay}" />

--- a/OnlyR/Properties/Resources.resx
+++ b/OnlyR/Properties/Resources.resx
@@ -211,7 +211,7 @@
     <value>Recording</value>
   </data>
   <data name="RECORDINGS_FOLDER_TOOLTIP" xml:space="preserve">
-    <value>Recordings folder</value>
+    <value>Open recordings folder</value>
     <comment>Tooltip for the button that opens the recordings folder</comment>
   </data>
   <data name="RECORDING_SALVAGED" xml:space="preserve">
@@ -270,7 +270,7 @@
     <comment>Settings page combobox title</comment>
   </data>
   <data name="SETTINGS_RECORDINGS_BTN" xml:space="preserve">
-    <value>Recordings...</value>
+    <value>Open recordings...</value>
     <comment>Settings page Recordings button caption</comment>
   </data>
   <data name="SETTINGS_RECORDINGS_FOLDER" xml:space="preserve">

--- a/OnlyR/ViewModel/SettingsPageViewModel.cs
+++ b/OnlyR/ViewModel/SettingsPageViewModel.cs
@@ -131,6 +131,7 @@ public class SettingsPageViewModel : ObservableObject, IPage
             if (_optionsService.Options.SilenceAsVolumePercentage != value)
             {
                 _optionsService.Options.SilenceAsVolumePercentage = value;
+                OnPropertyChanged();
             }
         }
     }


### PR DESCRIPTION
## What does this implement/fix?

This PR improves accessibility on the settings page.

### Changes made:
- Added `ToString()` overrides for settings page combo box item models so screen readers can announce the selected option text reliably.
- Improved the silence detection slider accessibility by making its label available through UI Automation and ensuring value changes notify the UI correctly.
- Fixed incorrect `AutomationProperties.Name` bindings on the settings page folder controls.
- Updated the recordings button text/tooltip in the base resources so the label matches the actual action: opening the recordings folder.

## Does this close any currently open issues?

No.

## Any other comments?

I have local zh-CN translation updates for these strings as well, but I have not included non-native resource files in this PR in line with `CONTRIBUTING.md`.