### PR TITLE
Simultaneous microphone + loopback recording

### DIFF
--- a/OnlyR.Core/Recorder/AudioRecorder.cs
+++ b/OnlyR.Core/Recorder/AudioRecorder.cs
@@ -338,14 +338,19 @@ public sealed class AudioRecorder : IDisposable
 
     private static void CheckRecordingDevice(RecordingConfig recordingConfig)
     {
+        // "None" selected (loopback-only): no microphone needed, so skip the input-device guard.
+        if (recordingConfig.RecordingDevice == RecordingConfig.EmptyRecordingDeviceId)
+        {
+            return;
+        }
+
         var deviceCount = WaveIn.DeviceCount;
         if (deviceCount == 0)
         {
             throw new NoDevicesException();
         }
 
-        if (recordingConfig.RecordingDevice != RecordingConfig.EmptyRecordingDeviceId
-            && recordingConfig.RecordingDevice >= deviceCount)
+        if (recordingConfig.RecordingDevice >= deviceCount)
         {
             recordingConfig.RecordingDevice = 0;
         }

--- a/OnlyR.Core/Recorder/AudioRecorder.cs
+++ b/OnlyR.Core/Recorder/AudioRecorder.cs
@@ -1,5 +1,6 @@
 ﻿using NAudio.Lame;
 using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
 using OnlyR.Core.Enums;
 using OnlyR.Core.EventArgs;
 using OnlyR.Core.Models;
@@ -24,6 +25,10 @@ public sealed class AudioRecorder : IDisposable
     private const int RequiredReportingIntervalMs = 40;
     private const int VuSpeed = 5;
 
+    // Caps how far the microphone buffer may grow in the mixed path, bounding
+    // drift between the two independent capture clocks.
+    private const int MixBufferSeconds = 5;
+
     private Stream? _audioWriter;
     private IWaveIn? _waveSource;
     private WaveOutEvent? _silenceWaveOut;
@@ -33,6 +38,17 @@ public sealed class AudioRecorder : IDisposable
     private bool _isPaused;
     private string? _tempRecordingFilePath;
     private string? _finalRecordingFilePath;
+
+    // Mixed (microphone + loopback) recording path. Only used when both sources are active.
+    private WaveInEvent? _micCapture;
+    private WasapiLoopbackCapture? _loopbackCapture;
+    private BufferedWaveProvider? _micBuffer;
+    private BufferedWaveProvider? _loopbackBuffer;
+    private MixingSampleProvider? _mixer;
+    private float[]? _mixSampleBuffer;
+    private byte[]? _mixPcmBuffer;
+    private int _outputSampleRate;
+    private int _outputChannelCount;
 
     private int _dampedLevel;
 
@@ -78,38 +94,16 @@ public sealed class AudioRecorder : IDisposable
         {
             CheckRecordingDevice(recordingConfig);
 
-            if (recordingConfig.UseLoopbackCapture)
+            var captureMic = recordingConfig.RecordingDevice != RecordingConfig.EmptyRecordingDeviceId;
+
+            if (captureMic && recordingConfig.UseLoopbackCapture)
             {
-                _waveSource = new WasapiLoopbackCapture();
-                ConfigureSilenceOut();
+                StartMixedRecording(recordingConfig);
             }
             else
             {
-                _waveSource = new WaveIn
-                {
-                    WaveFormat = new WaveFormat(recordingConfig.SampleRate, recordingConfig.ChannelCount),
-                    DeviceNumber = recordingConfig.RecordingDevice,
-                };
+                StartSingleSourceRecording(recordingConfig);
             }
-
-            InitAggregator(_waveSource.WaveFormat.SampleRate);
-            InitFader(_waveSource.WaveFormat.SampleRate);
-
-            _waveSource.DataAvailable += WaveSourceDataAvailableHandler;
-            _waveSource.RecordingStopped += WaveSourceRecordingStoppedHandler;
-
-            _audioWriter = recordingConfig.Codec switch
-            {
-                AudioCodec.Mp3 => new LameMP3FileWriter(
-                    recordingConfig.DestFilePath,
-                    _waveSource.WaveFormat,
-                    recordingConfig.Mp3BitRate!.Value,
-                    CreateTag(recordingConfig)),
-                AudioCodec.Wav => new WaveFileWriter(recordingConfig.DestFilePath, _waveSource.WaveFormat),
-                _ => throw new NotSupportedException("Unsupported codec"),
-            };
-
-            _waveSource.StartRecording();
 
             _tempRecordingFilePath = recordingConfig.DestFilePath;
             _finalRecordingFilePath = recordingConfig.FinalFilePath;
@@ -122,17 +116,138 @@ public sealed class AudioRecorder : IDisposable
         }
     }
 
-    private void ConfigureSilenceOut()
+    // Single-source recording (microphone-only or loopback-only) - the original, unchanged pipeline.
+    private void StartSingleSourceRecording(RecordingConfig recordingConfig)
+    {
+        if (recordingConfig.UseLoopbackCapture)
+        {
+            _waveSource = new WasapiLoopbackCapture();
+            ConfigureSilenceOut(_waveSource.WaveFormat);
+        }
+        else
+        {
+            _waveSource = new WaveIn
+            {
+                WaveFormat = new WaveFormat(recordingConfig.SampleRate, recordingConfig.ChannelCount),
+                DeviceNumber = recordingConfig.RecordingDevice,
+            };
+        }
+
+        InitAggregator(_waveSource.WaveFormat.SampleRate);
+        InitFader(_waveSource.WaveFormat.SampleRate);
+
+        _waveSource.DataAvailable += WaveSourceDataAvailableHandler;
+        _waveSource.RecordingStopped += WaveSourceRecordingStoppedHandler;
+
+        _audioWriter = CreateAudioWriter(recordingConfig, _waveSource.WaveFormat);
+
+        _waveSource.StartRecording();
+    }
+
+    // Mixed recording: microphone + system loopback combined into a single output stream.
+    // Each capture fills its own buffer; reads are clocked off the loopback capture (kept ticking
+    // by the silence-out trick) and the two streams are summed via a MixingSampleProvider.
+    private void StartMixedRecording(RecordingConfig recordingConfig)
+    {
+        _outputSampleRate = recordingConfig.SampleRate;
+        _outputChannelCount = recordingConfig.ChannelCount;
+
+        // Output matches single-source recordings: 16-bit PCM at the configured rate/channels.
+        var outputFormat = new WaveFormat(recordingConfig.SampleRate, recordingConfig.ChannelCount);
+
+        _micCapture = new WaveInEvent
+        {
+            WaveFormat = outputFormat,
+            DeviceNumber = recordingConfig.RecordingDevice,
+        };
+        _micBuffer = new BufferedWaveProvider(_micCapture.WaveFormat)
+        {
+            DiscardOnBufferOverflow = true,
+            BufferDuration = TimeSpan.FromSeconds(MixBufferSeconds),
+        };
+        _micCapture.DataAvailable += MicCaptureDataAvailableHandler;
+
+        _loopbackCapture = new WasapiLoopbackCapture();
+        _loopbackBuffer = new BufferedWaveProvider(_loopbackCapture.WaveFormat)
+        {
+            DiscardOnBufferOverflow = true,
+            BufferDuration = TimeSpan.FromSeconds(MixBufferSeconds),
+        };
+        _loopbackCapture.DataAvailable += LoopbackCaptureDataAvailableHandler;
+        _loopbackCapture.RecordingStopped += WaveSourceRecordingStoppedHandler;
+
+        ConfigureSilenceOut(_loopbackCapture.WaveFormat);
+
+        var mixFormat = WaveFormat.CreateIeeeFloatWaveFormat(recordingConfig.SampleRate, recordingConfig.ChannelCount);
+        _mixer = new MixingSampleProvider(mixFormat) { ReadFully = true };
+        _mixer.AddMixerInput(ConvertToOutputFormat(_micBuffer.ToSampleProvider()));
+        _mixer.AddMixerInput(ConvertToOutputFormat(_loopbackBuffer.ToSampleProvider()));
+
+        InitAggregator(recordingConfig.SampleRate);
+        InitFader(recordingConfig.SampleRate);
+
+        _audioWriter = CreateAudioWriter(recordingConfig, outputFormat);
+
+        _micCapture.StartRecording();
+        _loopbackCapture.StartRecording();
+    }
+
+    private static Stream CreateAudioWriter(RecordingConfig recordingConfig, WaveFormat waveFormat)
+    {
+        return recordingConfig.Codec switch
+        {
+            AudioCodec.Mp3 => new LameMP3FileWriter(
+                recordingConfig.DestFilePath,
+                waveFormat,
+                recordingConfig.Mp3BitRate!.Value,
+                CreateTag(recordingConfig)),
+            AudioCodec.Wav => new WaveFileWriter(recordingConfig.DestFilePath, waveFormat),
+            _ => throw new NotSupportedException("Unsupported codec"),
+        };
+    }
+
+    // Converts a capture to the output format (channel count then sample rate) so it can be mixed.
+    private ISampleProvider ConvertToOutputFormat(ISampleProvider source)
+    {
+        var result = MatchChannels(source, _outputChannelCount);
+
+        if (result.WaveFormat.SampleRate != _outputSampleRate)
+        {
+            result = new WdlResamplingSampleProvider(result, _outputSampleRate);
+        }
+
+        return result;
+    }
+
+    private static ISampleProvider MatchChannels(ISampleProvider source, int targetChannels)
+    {
+        var channels = source.WaveFormat.Channels;
+        if (channels == targetChannels)
+        {
+            return source;
+        }
+
+        if (channels == 2 && targetChannels == 1)
+        {
+            return new StereoToMonoSampleProvider(source);
+        }
+
+        if (channels == 1 && targetChannels == 2)
+        {
+            return new MonoToStereoSampleProvider(source);
+        }
+
+        // ponytail: only 1<->2 conversion supported; multichannel loopback is rare.
+        // Upgrade with a MultiplexingSampleProvider downmix if it's ever reported.
+        throw new NotSupportedException($"Cannot mix {channels}-channel audio into {targetChannels}-channel output.");
+    }
+
+    private void ConfigureSilenceOut(WaveFormat waveFormat)
     {
         // WasapiLoopbackCapture doesn't record any audio when nothing is playing
         // so we must play some silence!
 
-        if (_waveSource?.WaveFormat == null)
-        {
-            return;
-        }
-
-        var silence = new SilenceProvider(_waveSource.WaveFormat);
+        var silence = new SilenceProvider(waveFormat);
         _silenceWaveOut = new WaveOutEvent();
         _silenceWaveOut.Init(silence);
         _silenceWaveOut.Play();
@@ -195,10 +310,17 @@ public sealed class AudioRecorder : IDisposable
             }
             else
             {
-                _waveSource?.StopRecording();
-                _silenceWaveOut?.Stop();
+                StopCaptures();
             }
         }
+    }
+
+    private void StopCaptures()
+    {
+        _waveSource?.StopRecording();
+        _micCapture?.StopRecording();
+        _loopbackCapture?.StopRecording();
+        _silenceWaveOut?.Stop();
     }
 
     private static ID3TagData CreateTag(RecordingConfig recordingConfig)
@@ -222,7 +344,8 @@ public sealed class AudioRecorder : IDisposable
             throw new NoDevicesException();
         }
 
-        if (!recordingConfig.UseLoopbackCapture && recordingConfig.RecordingDevice >= deviceCount)
+        if (recordingConfig.RecordingDevice != RecordingConfig.EmptyRecordingDeviceId
+            && recordingConfig.RecordingDevice >= deviceCount)
         {
             recordingConfig.RecordingDevice = 0;
         }
@@ -303,6 +426,97 @@ public sealed class AudioRecorder : IDisposable
         }
     }
 
+    private void MicCaptureDataAvailableHandler(object? sender, WaveInEventArgs waveInEventArgs)
+    {
+        if (_isPaused)
+        {
+            return;
+        }
+
+        // The microphone just fills its buffer; the loopback capture clocks the actual mixing.
+        _micBuffer?.AddSamples(waveInEventArgs.Buffer, 0, waveInEventArgs.BytesRecorded);
+    }
+
+    private void LoopbackCaptureDataAvailableHandler(object? sender, WaveInEventArgs waveInEventArgs)
+    {
+        if (_isPaused)
+        {
+            return;
+        }
+
+        _loopbackBuffer?.AddSamples(waveInEventArgs.Buffer, 0, waveInEventArgs.BytesRecorded);
+        PumpMixedAudio(waveInEventArgs.BytesRecorded);
+    }
+
+    // Reads the amount of mixed audio that corresponds to the loopback data just received,
+    // keeping the output paced to real time. Reads pull from both source buffers (ReadFully
+    // pads brief gaps with silence), the summed result is clamped, faded, metered and written.
+    private void PumpMixedAudio(int loopbackBytesRecorded)
+    {
+        if (_mixer == null || _loopbackCapture == null || _audioWriter == null)
+        {
+            return;
+        }
+
+        var loopbackFormat = _loopbackCapture.WaveFormat;
+        var frames = loopbackBytesRecorded / loopbackFormat.BlockAlign;
+        var outputFrames = (int)((long)frames * _outputSampleRate / loopbackFormat.SampleRate);
+        var sampleCount = outputFrames * _outputChannelCount;
+        if (sampleCount <= 0)
+        {
+            return;
+        }
+
+        if (_mixSampleBuffer == null || _mixSampleBuffer.Length < sampleCount)
+        {
+            _mixSampleBuffer = new float[sampleCount];
+        }
+
+        var samplesRead = _mixer.Read(_mixSampleBuffer, 0, sampleCount);
+        if (samplesRead <= 0)
+        {
+            return;
+        }
+
+        // Summed sources can exceed the [-1, 1] range, so hard-clamp to prevent wrap-around.
+        for (var index = 0; index < samplesRead; ++index)
+        {
+            var sample = _mixSampleBuffer[index];
+            _mixSampleBuffer[index] = sample > 1f ? 1f : sample < -1f ? -1f : sample;
+        }
+
+        if (_fader?.Active == true)
+        {
+            _fader.FadeBuffer(_mixSampleBuffer, samplesRead);
+        }
+
+        for (var index = 0; index < samplesRead; ++index)
+        {
+            _sampleAggregator?.Add(_mixSampleBuffer[index]);
+        }
+
+        WriteMixedAsPcm16(_mixSampleBuffer, samplesRead);
+    }
+
+    private void WriteMixedAsPcm16(float[] samples, int sampleCount)
+    {
+        var byteCount = sampleCount * 2;
+        if (_mixPcmBuffer == null || _mixPcmBuffer.Length < byteCount)
+        {
+            _mixPcmBuffer = new byte[byteCount];
+        }
+
+        var offset = 0;
+        for (var index = 0; index < sampleCount; ++index)
+        {
+            var value = (short)(samples[index] * 32767f);
+            _mixPcmBuffer[offset++] = (byte)(value & 0xFF);
+            _mixPcmBuffer[offset++] = (byte)((value >> 8) & 0xFF);
+        }
+
+        _audioWriter?.Write(_mixPcmBuffer, 0, byteCount);
+    }
+
     private void OnRecordingStatusChangeEvent(RecordingStatusChangeEventArgs e)
     {
         _recordingStatus = e.RecordingStatus;
@@ -333,8 +547,7 @@ public sealed class AudioRecorder : IDisposable
 
     private void FadeCompleteHandler(object? sender, System.EventArgs e)
     {
-        _waveSource?.StopRecording();
-        _silenceWaveOut?.Stop();
+        StopCaptures();
     }
 
     private void Cleanup()
@@ -345,6 +558,16 @@ public sealed class AudioRecorder : IDisposable
 
         _waveSource?.Dispose();
         _waveSource = null;
+
+        _micCapture?.Dispose();
+        _micCapture = null;
+
+        _loopbackCapture?.Dispose();
+        _loopbackCapture = null;
+
+        _micBuffer = null;
+        _loopbackBuffer = null;
+        _mixer = null;
 
         _silenceWaveOut?.Dispose();
         _silenceWaveOut = null;

--- a/OnlyR.Core/Recorder/RecordingConfig.cs
+++ b/OnlyR.Core/Recorder/RecordingConfig.cs
@@ -9,6 +9,11 @@ namespace OnlyR.Core.Recorder;
 public class RecordingConfig
 {
     /// <summary>
+    /// Sentinel device id meaning "no microphone selected" (the "None" entry).
+    /// </summary>
+    public const int EmptyRecordingDeviceId = -1;
+
+    /// <summary>
     /// The audio recording device Id.
     /// </summary>
     public int RecordingDevice { get; set; }

--- a/OnlyR.Core/Recorder/VolumeFader.cs
+++ b/OnlyR.Core/Recorder/VolumeFader.cs
@@ -68,6 +68,28 @@ internal sealed class VolumeFader
         }
     }
 
+    /// <summary>
+    /// Modifies a buffer of float samples in accord with the current fading status.
+    /// Used by the mixed (mic + loopback) recording path.
+    /// </summary>
+    /// <param name="buffer">The interleaved float audio samples.</param>
+    /// <param name="sampleCount">The number of samples to modify.</param>
+    public void FadeBuffer(float[] buffer, int sampleCount)
+    {
+        _sampleCountModified += sampleCount;
+        var volumeAdjustmentFraction = 1 - ((float)_sampleCountModified / _sampleCountToModify);
+
+        for (var index = 0; index < sampleCount; ++index)
+        {
+            buffer[index] *= volumeAdjustmentFraction;
+        }
+
+        if (volumeAdjustmentFraction <= 0)
+        {
+            OnFadeComplete();
+        }
+    }
+
     private void OnFadeComplete()
     {
         FadeComplete?.Invoke(this, System.EventArgs.Empty);

--- a/OnlyR.Tests/Mocks/MockAudioService.cs
+++ b/OnlyR.Tests/Mocks/MockAudioService.cs
@@ -4,6 +4,7 @@ using OnlyR.Model;
 using OnlyR.Services.Audio;
 using OnlyR.Services.Options;
 using System;
+using System.Collections.Generic;
 using System.Windows.Threading;
 
 namespace OnlyR.Tests.Mocks;
@@ -15,6 +16,12 @@ internal sealed class MockAudioService : IAudioService
 {
     private readonly DispatcherTimer _timer;
     private readonly Random _random;
+    private readonly List<RecordingDeviceItem> _devices =
+    [
+        new RecordingDeviceItem(1, "Dev1"),
+        new RecordingDeviceItem(2, "Dev2"),
+    ];
+
     private RecordingStatus _status;
 
     public MockAudioService()
@@ -40,11 +47,15 @@ internal sealed class MockAudioService : IAudioService
 
     public RecordingDeviceItem[] GetRecordingDeviceList()
     {
-        return
-        [
-            new RecordingDeviceItem(1, "Dev1"),
-            new RecordingDeviceItem(2, "Dev2")
-        ];
+        return _devices.ToArray();
+    }
+
+    /// <summary>
+    /// Simulates a recording device becoming available while the app is running.
+    /// </summary>
+    public void AddRecordingDevice(int id, string name)
+    {
+        _devices.Add(new RecordingDeviceItem(id, name));
     }
 
     public void StartRecording(RecordingCandidate candidateFile, IOptionsService optionsService)

--- a/OnlyR.Tests/TestOptionsSanitize.cs
+++ b/OnlyR.Tests/TestOptionsSanitize.cs
@@ -1,4 +1,5 @@
 using OnlyR.Core.Enums;
+using OnlyR.Core.Recorder;
 using OnlyR.Services.Options;
 using System.Threading.Tasks;
 
@@ -101,6 +102,71 @@ public sealed class TestOptionsSanitize
         options.Sanitize();
         await Assert.That(options.Genre).IsNotNull();
         await Assert.That(options.Genre).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task DualInputMigrationForcesExistingLoopbackUserToNone()
+    {
+        // Pre-feature options: loopback on with a real device selected.
+        var options = new Options
+        {
+            UseLoopbackCapture = true,
+            RecordingDevice = 2,
+            DualInputMigrated = false,
+        };
+
+        options.Sanitize();
+
+        // Must keep recording system audio only - device forced to "None".
+        await Assert.That(options.RecordingDevice).IsEqualTo(RecordingConfig.EmptyRecordingDeviceId);
+        await Assert.That(options.DualInputMigrated).IsTrue();
+    }
+
+    [Test]
+    public async Task DualInputMigrationLeavesExistingMicUserUntouched()
+    {
+        var options = new Options
+        {
+            UseLoopbackCapture = false,
+            RecordingDevice = 2,
+            DualInputMigrated = false,
+        };
+
+        options.Sanitize();
+
+        await Assert.That(options.RecordingDevice).IsEqualTo(2);
+        await Assert.That(options.DualInputMigrated).IsTrue();
+    }
+
+    [Test]
+    public async Task DualInputMigrationDoesNotRerunForDeliberateBothSelection()
+    {
+        // Already migrated: user has deliberately chosen device + loopback (both).
+        var options = new Options
+        {
+            UseLoopbackCapture = true,
+            RecordingDevice = 2,
+            DualInputMigrated = true,
+        };
+
+        options.Sanitize();
+
+        await Assert.That(options.RecordingDevice).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SanitizePreservesNoneDeviceSentinel()
+    {
+        var options = new Options
+        {
+            RecordingDevice = RecordingConfig.EmptyRecordingDeviceId,
+            UseLoopbackCapture = true,
+            DualInputMigrated = true,
+        };
+
+        options.Sanitize();
+
+        await Assert.That(options.RecordingDevice).IsEqualTo(RecordingConfig.EmptyRecordingDeviceId);
     }
 
     [Test]

--- a/OnlyR.Tests/TestSettingsPageViewModel.cs
+++ b/OnlyR.Tests/TestSettingsPageViewModel.cs
@@ -475,6 +475,37 @@ public sealed class TestSettingsPageViewModel
 
     [Test]
     [NotInParallel("Messenger")]
+    public async Task ActivatedRefreshesRecordingDeviceList()
+    {
+        var (before, after) = await StaThreadHelper.RunOnSta(() =>
+        {
+            var audioService = new MockAudioService();
+
+            var optionsMock = Mock.Of<IOptionsService>();
+            optionsMock.Options.Returns(new Options());
+            optionsMock.GetSupportedSampleRates().Returns([new SampleRateItem("44.1 kHz", 44100)]);
+            optionsMock.GetSupportedChannels().Returns([new ChannelItem("Mono", 1)]);
+            optionsMock.GetSupportedMp3BitRates().Returns([new BitRateItem("96 kbps", 96)]);
+
+            var commandLineMock = Mock.Of<ICommandLineService>();
+
+            var vm = new SettingsPageViewModel(audioService, optionsMock.Object, commandLineMock.Object);
+
+            var initialCount = vm.RecordingDevices.Count();
+
+            // A device becomes available after the page was first constructed.
+            audioService.AddRecordingDevice(3, "Dev3");
+            vm.Activated(null);
+
+            return (initialCount, vm.RecordingDevices.Count());
+        });
+
+        await Assert.That(before).IsEqualTo(2);
+        await Assert.That(after).IsEqualTo(3);
+    }
+
+    [Test]
+    [NotInParallel("Messenger")]
     public async Task LanguageIdSetterFiresPropertyChanged()
     {
         var changedProperties = await StaThreadHelper.RunOnSta(() =>

--- a/OnlyR.Tests/TestSettingsPageViewModel.cs
+++ b/OnlyR.Tests/TestSettingsPageViewModel.cs
@@ -261,20 +261,6 @@ public sealed class TestSettingsPageViewModel
 
     [Test]
     [NotInParallel("Messenger")]
-    public async Task UseLoopbackCaptureUpdatesNotUsingLoopback()
-    {
-        var notUsingLoopback = await StaThreadHelper.RunOnSta(() =>
-        {
-            var vm = CreateViewModel();
-            vm.UseLoopbackCapture = true;
-            return vm.NotUsingLoopbackCapture;
-        });
-
-        await Assert.That(notUsingLoopback).IsFalse();
-    }
-
-    [Test]
-    [NotInParallel("Messenger")]
     public async Task GenreRoundTrips()
     {
         var result = await StaThreadHelper.RunOnSta(() =>
@@ -537,19 +523,6 @@ public sealed class TestSettingsPageViewModel
         });
 
         // Default codec is MP3
-        await Assert.That(result).IsTrue();
-    }
-
-    [Test]
-    [NotInParallel("Messenger")]
-    public async Task NotUsingLoopbackCaptureDefaultTrue()
-    {
-        var result = await StaThreadHelper.RunOnSta(() =>
-        {
-            var vm = CreateViewModel();
-            return vm.NotUsingLoopbackCapture;
-        });
-
         await Assert.That(result).IsTrue();
     }
 

--- a/OnlyR/Pages/RecordingPage.xaml
+++ b/OnlyR/Pages/RecordingPage.xaml
@@ -123,9 +123,10 @@
                 AutomationProperties.AutomationId="StartBtn"
                 AutomationProperties.Name="{x:Static resx:Resources.START_RECORDING_TOOLTIP}"
                 Command="{Binding StartRecordingCommand}"
-                IsEnabled="{Binding IsNotRecording}"
+                IsEnabled="{Binding CanRecord}"
                 Style="{StaticResource StartRecordingBtnStyle}"
-                ToolTip="{x:Static resx:Resources.START_RECORDING_TOOLTIP}"
+                ToolTip="{Binding RecordTooltip}"
+                ToolTipService.ShowOnDisabled="True"
                 Visibility="{Binding Path=IsReadyToRecord, Converter={StaticResource BoolToVis}}">
                 <StackPanel Orientation="Vertical">
                     <materialDesign:PackIcon

--- a/OnlyR/Pages/SettingsPage.xaml
+++ b/OnlyR/Pages/SettingsPage.xaml
@@ -101,7 +101,6 @@
                     AutomationProperties.AutomationId="RecordingDevice"
                     AutomationProperties.Name="{x:Static resx:Resources.SETTINGS_RECORDING_DEVICE}"
                     DisplayMemberPath="DeviceName"
-                    IsEnabled="{Binding NotUsingLoopbackCapture}"
                     ItemsSource="{Binding RecordingDevices}"
                     SelectedValue="{Binding RecordingDeviceId, Mode=TwoWay}"
                     SelectedValuePath="DeviceId"

--- a/OnlyR/Properties/Resources.Designer.cs
+++ b/OnlyR/Properties/Resources.Designer.cs
@@ -266,6 +266,24 @@ namespace OnlyR.Properties {
                 return ResourceManager.GetString("NO_AUDIO_PRODUCED", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        public static string RECORDING_DEVICE_NONE {
+            get {
+                return ResourceManager.GetString("RECORDING_DEVICE_NONE", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select a recording device or enable loopback capture.
+        /// </summary>
+        public static string NO_AUDIO_SOURCE_HINT {
+            get {
+                return ResourceManager.GetString("NO_AUDIO_SOURCE_HINT", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to No limit.

--- a/OnlyR/Properties/Resources.resx
+++ b/OnlyR/Properties/Resources.resx
@@ -374,4 +374,12 @@
   <data name="NO_AUDIO_PRODUCED" xml:space="preserve">
     <value>No audio produced!</value>
   </data>
+  <data name="RECORDING_DEVICE_NONE" xml:space="preserve">
+    <value>None</value>
+    <comment>First (no microphone) entry in the Settings =&gt; Recording device list</comment>
+  </data>
+  <data name="NO_AUDIO_SOURCE_HINT" xml:space="preserve">
+    <value>Select a recording device or enable loopback capture</value>
+    <comment>Tooltip shown when no audio source is selected and recording is disabled</comment>
+  </data>
 </root>

--- a/OnlyR/Services/Audio/AudioService.cs
+++ b/OnlyR/Services/Audio/AudioService.cs
@@ -54,8 +54,14 @@ public sealed class AudioService : IAudioService, IDisposable
     /// <returns>List of available devices</returns>
     public RecordingDeviceItem[] GetRecordingDeviceList()
     {
-        var devices = AudioRecorder.GetRecordingDeviceList();
-        return devices.Select(Convert).ToArray();
+        var devices = AudioRecorder.GetRecordingDeviceList().Select(Convert).ToList();
+
+        // "None" lets the user record system loopback only, or (with a device selected) combine both.
+        devices.Insert(0, new RecordingDeviceItem(
+            RecordingConfig.EmptyRecordingDeviceId,
+            OnlyR.Properties.Resources.RECORDING_DEVICE_NONE));
+
+        return devices.ToArray();
     }
 
     private RecordingDeviceItem Convert(RecordingDeviceInfo deviceInfo) =>

--- a/OnlyR/Services/Options/Options.cs
+++ b/OnlyR/Services/Options/Options.cs
@@ -1,4 +1,5 @@
 ﻿using OnlyR.Core.Enums;
+using OnlyR.Core.Recorder;
 using OnlyR.Model;
 using OnlyR.Utils;
 using System;
@@ -62,6 +63,12 @@ public class Options
     public int RecordingDevice { get; set; }
 
     public bool UseLoopbackCapture { get; set; }
+
+    /// <summary>
+    /// Tracks whether the one-time migration to the dual-input recording model has run.
+    /// Absent (false) in options files written before the feature existed.
+    /// </summary>
+    public bool DualInputMigrated { get; set; }
 
     public bool FadeOut { get; set; }
 
@@ -146,7 +153,7 @@ public class Options
             MaxRecordingTimeSeconds = DefaultMaxRecordingSeconds;
         }
 
-        if (RecordingDevice < 0)
+        if (RecordingDevice < RecordingConfig.EmptyRecordingDeviceId)
         {
             RecordingDevice = DefaultRecordingDevice;
         }
@@ -165,6 +172,20 @@ public class Options
         if (Codec != AudioCodec.Mp3 && Codec != AudioCodec.Wav)
         {
             Codec = AudioCodec.Mp3;
+        }
+
+        // Migrate existing "Use loopback capture" users to the dual-input model.
+        // Loopback previously meant "system audio only" regardless of the selected device;
+        // now "selected device + loopback" means "record both". Force pre-existing loopback
+        // users to "None" so they keep recording system audio only after upgrading.
+        if (!DualInputMigrated)
+        {
+            if (UseLoopbackCapture)
+            {
+                RecordingDevice = RecordingConfig.EmptyRecordingDeviceId;
+            }
+
+            DualInputMigrated = true;
         }
 
         // Migrate legacy DarkMode bool to AppTheme enum

--- a/OnlyR/ViewModel/RecordingPageViewModel.cs
+++ b/OnlyR/ViewModel/RecordingPageViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using OnlyR.Core.Enums;
+using OnlyR.Core.Recorder;
 using OnlyR.Exceptions;
 using OnlyR.Model;
 using OnlyR.Services.Audio;
@@ -118,6 +119,11 @@ public class RecordingPageViewModel : ObservableObject, IPage
             OnPropertyChanged(nameof(IsMaxRecordingTimeSpecified));
             OnPropertyChanged(nameof(ShowStopOnly));
             OnPropertyChanged(nameof(ShowStopAndPause));
+
+            // The audio source may have changed in Settings.
+            OnPropertyChanged(nameof(HasAudioSource));
+            OnPropertyChanged(nameof(CanRecord));
+            OnPropertyChanged(nameof(RecordTooltip));
         }
     }
 
@@ -169,6 +175,17 @@ public class RecordingPageViewModel : ObservableObject, IPage
     public bool IsReadyToRecord => RecordingStatus != RecordingStatus.Recording &&
                                    RecordingStatus != RecordingStatus.StopRequested &&
                                    RecordingStatus != RecordingStatus.Paused;
+
+    public bool HasAudioSource =>
+        _optionsService.Options.RecordingDevice != RecordingConfig.EmptyRecordingDeviceId ||
+        _optionsService.Options.UseLoopbackCapture;
+
+    public bool CanRecord => IsReadyToRecord && HasAudioSource;
+
+    public string RecordTooltip =>
+        HasAudioSource
+            ? Properties.Resources.START_RECORDING_TOOLTIP
+            : Properties.Resources.NO_AUDIO_SOURCE_HINT;
 
     public bool ShowStopOnly => IsRecordingOrStopping && !_optionsService.Options.ShowPauseRecordingButton;
 
@@ -226,6 +243,7 @@ public class RecordingPageViewModel : ObservableObject, IPage
                 OnPropertyChanged(nameof(IsRecordingOrPaused));
                 OnPropertyChanged(nameof(CanPause));
                 OnPropertyChanged(nameof(IsReadyToRecord));
+                OnPropertyChanged(nameof(CanRecord));
                 OnPropertyChanged(nameof(IsRecordingOrStopping));
                 OnPropertyChanged(nameof(ShowStopOnly));
                 OnPropertyChanged(nameof(ShowStopAndPause));
@@ -501,6 +519,12 @@ public class RecordingPageViewModel : ObservableObject, IPage
 
     private void StartRecording()
     {
+        if (!HasAudioSource)
+        {
+            // No microphone selected and loopback disabled - nothing to record.
+            return;
+        }
+
         try
         {
             ClearErrorMsg();

--- a/OnlyR/ViewModel/SettingsPageViewModel.cs
+++ b/OnlyR/ViewModel/SettingsPageViewModel.cs
@@ -298,8 +298,6 @@ public class SettingsPageViewModel : ObservableObject, IPage
 
     public IEnumerable<RecordingDeviceItem> RecordingDevices => _recordingDevices;
 
-    public bool NotUsingLoopbackCapture => !UseLoopbackCapture;
-
     public int RecordingDeviceId
     {
         get => _optionsService.Options.RecordingDevice;
@@ -320,7 +318,6 @@ public class SettingsPageViewModel : ObservableObject, IPage
             if (_optionsService.Options.UseLoopbackCapture != value)
             {
                 _optionsService.Options.UseLoopbackCapture = value;
-                OnPropertyChanged(nameof(NotUsingLoopbackCapture));
             }
         }
     }

--- a/OnlyR/ViewModel/SettingsPageViewModel.cs
+++ b/OnlyR/ViewModel/SettingsPageViewModel.cs
@@ -23,8 +23,9 @@ namespace OnlyR.ViewModel;
 /// </summary>
 public class SettingsPageViewModel : ObservableObject, IPage
 {
+    private readonly IAudioService _audioService;
     private readonly IOptionsService _optionsService;
-    private readonly RecordingDeviceItem[] _recordingDevices;
+    private RecordingDeviceItem[] _recordingDevices;
     private readonly SampleRateItem[] _sampleRates;
     private readonly ChannelItem[] _channels;
     private readonly BitRateItem[] _bitRates;
@@ -43,11 +44,12 @@ public class SettingsPageViewModel : ObservableObject, IPage
         ICommandLineService commandLineService)
     {
         WeakReferenceMessenger.Default.Register<BeforeShutDownMessage>(this, OnShutDown);
+        _audioService = audioService;
         _optionsService = optionsService;
 
         _commandLineService = commandLineService;
 
-        _recordingDevices = audioService.GetRecordingDeviceList();
+        _recordingDevices = _audioService.GetRecordingDeviceList();
         _sampleRates = optionsService.GetSupportedSampleRates();
         _channels = optionsService.GetSupportedChannels();
         _bitRates = optionsService.GetSupportedMp3BitRates();
@@ -367,7 +369,12 @@ public class SettingsPageViewModel : ObservableObject, IPage
 
     public void Activated(object? state)
     {
-        // nothing to do
+        // The set of audio devices can change while the app is running (e.g. a mic is
+        // enabled or plugged in), so re-enumerate each time the page is shown. Re-raising
+        // RecordingDeviceId lets the combo re-select the saved device if it's still present.
+        _recordingDevices = _audioService.GetRecordingDeviceList();
+        OnPropertyChanged(nameof(RecordingDevices));
+        OnPropertyChanged(nameof(RecordingDeviceId));
     }
 
     private static ThemeModeItem[] GenerateThemeModeItems() =>


### PR DESCRIPTION
> ⚠️ **Prototype / draft for feedback.** This is a clean re-implementation of the dual-input feature from the `2.2.0.2` pre-release. Opening as a draft so the approach can be reviewed before polishing. Looking for your thoughts on the UI and the mixing strategy, @AntonyCorbett.

Addresses #93 and #101 — record the **microphone and system loopback at the same time**.

## What's here

**Simultaneous mic + loopback recording** (`3d7db00`)
- New mixed-capture path in `AudioRecorder`, used **only when a device *and* loopback are both selected**. Mic-only and loopback-only stay on the original, unchanged pipeline — so existing behaviour can't regress.
- Each capture fills its own bounded `BufferedWaveProvider`; both are resampled / channel-matched to the output format and summed via NAudio's `MixingSampleProvider`. Reads are clocked off the loopback capture (kept ticking by the existing silence-out trick), summed samples are hard-clamped to `[-1,1]`, then written as 16-bit PCM so the output files are format-identical to single-source recordings.
- Fixes the pre-release bugs: both sources are buffered (no overflow), loopback is **resampled** rather than having its format force-set, and the mix is clamped to avoid clipping.

**UI** — a `None` entry is added to the recording-device list and the dropdown's "disabled while loopback" lock is removed, giving three modes:

| Recording device | Use loopback capture | Result |
|---|---|---|
| A device | ☐ | Microphone only *(unchanged)* |
| None | ☑ | System audio only *(unchanged)* |
| A device | ☑ | **Both, mixed (new)** |
| None | ☐ | *invalid → Record button disabled, with a hint* |

This follows your suggestion of a `None` entry rather than a separate "Audio source" dropdown.

**Backwards compatibility** — a one-time `DualInputMigrated` flag in `Options.Sanitize()` forces existing "Use loopback capture" users to `None`, so after upgrading they keep recording **system audio only** (not suddenly mic + system). Mic-only users are untouched; new installs default to mic-only.

**Bonus fix** (`2bbf2b4`, `dda039a`) — the recording-device list now refreshes when the Settings page opens, so a mic enabled/plugged-in after launch shows up without an app restart.

## Testing
- `dotnet build` clean (warnings-as-errors); **363 unit tests pass**, including new coverage for the migration and the device-list refresh.

## Known limitations (deferred)
- Bounded clock drift on very long dual recordings (the two devices have independent clocks); acceptable for typical use, full drift-correction left for later.
- Loopback devices reporting >2 channels throw a clear `NotSupportedException` (only 1↔2 conversion implemented).
- Arbitrary mic + speaker device pairs (the StepVoice-style request in #93) are out of scope here — this does mic + the **default** system loopback.
